### PR TITLE
Agrega verificación de mensaje de credenciales inválidas

### DIFF
--- a/src/test/java/com/robertorivas/automatizacion/pruebas/PruebasLogin.java
+++ b/src/test/java/com/robertorivas/automatizacion/pruebas/PruebasLogin.java
@@ -214,6 +214,8 @@ public class PruebasLogin extends PruebasBase {
         
         Assert.assertFalse(loginExitoso, "El login debería fallar con credenciales inválidas");
         Assert.assertTrue(hayErrores, "Debería mostrar errores con credenciales inválidas");
+        Assert.assertTrue(credencialesInvalidas,
+                "Debería mostrarse mensaje de credenciales inválidas");
     }
     
     @Test(dataProvider = "credencialesInvalidas", dataProviderClass = ProveedorDatos.class,


### PR DESCRIPTION
## Summary
- agrega `Assert.assertTrue(credencialesInvalidas)` luego de verificar errores

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c670b82083318d54a2ba3b086c43